### PR TITLE
Fix mSrcLoc.column value in lexer

### DIFF
--- a/src/lexer/lexer.hpp
+++ b/src/lexer/lexer.hpp
@@ -119,5 +119,6 @@ class Lexer {
 
    private:
     Token tokenizeCurrentStr();
+    char advance();
 };
 }  // namespace Crust


### PR DESCRIPTION
Add a standardized way to advance the iterator, which ensures that the srcLoc is advanced at each iteration as well. 